### PR TITLE
use Packit for Fedora integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ doc/source/tutorial/services.rst
 # Pyenv
 .python-version
 
+# RPM Packaging
+awscli.spec

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,8 +11,6 @@ downstream_package_name: awscli
 actions:
   post-upstream-clone:
   - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/rawhide/f/awscli.spec
-  - sed -i -e 's/botocore==[0-9.]\+/botocore/' setup.py
-  - sed -i -e 's/botocore==[0-9.]\+/botocore/' setup.cfg
 
 jobs:
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -11,6 +11,7 @@ downstream_package_name: awscli
 actions:
   post-upstream-clone:
   - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/epel9/f/awscli.spec
+  - sed 's/bcond_without  tests/bcond_with tests/g' -i awscli.spec
 
 jobs:
   - job: copr_build

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,7 +10,7 @@ downstream_package_name: awscli
 
 actions:
   post-upstream-clone:
-  - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/epel9/f/awscli.spec
+  - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/f37/f/awscli.spec
   - sed 's/bcond_without  tests/bcond_with tests/g' -i awscli.spec
 
 jobs:
@@ -18,8 +18,8 @@ jobs:
     trigger: pull_request
     packit_instances: ["stg"]
     targets:
-      - centos-stream+epel-next-9
-      - fedora-36-x86_64
+      - fedora-37-x86_64
+      # - centos-stream+epel-next-9
   - job: vm_image_build
     trigger: pull_request
     packit_instances: ["stg"]
@@ -32,20 +32,22 @@ jobs:
           share_with_accounts: ["727920394381"]
     image_customizations:
       packages: [awscli]
-      payload_repositories:
-      # for some reason, koji baseurl links don't work here
-      - rhsm: false
-        baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/9/Everything/x86_64/
-        check_gpg: false
-      - rhsm: false
-        baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/next/9/Everything/x86_64/
-        check_gpg: false
-      # docutils
-      - rhsm: false
-        baseurl: http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/
-        check_gpg: false
-    image_distribution: rhel-90
+    #   payload_repositories:
+    #   # for some reason, koji baseurl links don't work here
+    #   - rhsm: false
+    #     baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/9/Everything/x86_64/
+    #     check_gpg: false
+    #   - rhsm: false
+    #     baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/next/9/Everything/x86_64/
+    #     check_gpg: false
+    #   # docutils
+    #   - rhsm: false
+    #     baseurl: http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/
+    #     check_gpg: false
+    # image_distribution: rhel-90
+    image_distribution: fedora-37
     owner: packit-stg
     project: TomasTomecek-aws-cli-1
-    copr_chroot: centos-stream+epel-next-9-x86_64
+    # copr_chroot: centos-stream+epel-next-9-x86_64
+    copr_chroot: fedora-37-x86_64
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -32,8 +32,16 @@ jobs:
     image_customizations:
       packages: [awscli]
       payload_repositories:
+      # for some reason, koji baseurl links don't work here
       - rhsm: false
-        baseurl: https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/x86_64/
+        baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/9/Everything/x86_64/
+        check_gpg: false
+      - rhsm: false
+        baseurl: https://mirror.cs.princeton.edu/pub/mirrors/epel/next/9/Everything/x86_64/
+        check_gpg: false
+      # docutils
+      - rhsm: false
+        baseurl: http://mirror.stream.centos.org/9-stream/CRB/x86_64/os/
         check_gpg: false
     image_distribution: rhel-90
     owner: packit-stg

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -10,14 +10,14 @@ downstream_package_name: awscli
 
 actions:
   post-upstream-clone:
-  - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/rawhide/f/awscli.spec
+  - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/epel9/f/awscli.spec
 
 jobs:
   - job: copr_build
     trigger: pull_request
     packit_instances: ["stg"]
     targets:
-      - fedora-rawhide
+      - centos-stream+epel-next-9
   - job: vm_image_build
     trigger: pull_request
     packit_instances: ["stg"]
@@ -30,8 +30,8 @@ jobs:
           share_with_accounts: ["727920394381"]
     image_customizations:
       packages: [awscli]
-    image_distribution: fedora-rawhide
+    image_distribution: rhel-90
     owner: packit-stg
     project: TomasTomecek-aws-cli-1
-    copr_chroot: fedora-rawhide-x86_64
+    copr_chroot: centos-stream+epel-next-9
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -31,8 +31,12 @@ jobs:
           share_with_accounts: ["727920394381"]
     image_customizations:
       packages: [awscli]
+      payload_repositories:
+      - rhsm: false
+        baseurl: https://kojipkgs.fedoraproject.org/repos/epel9-build/latest/x86_64/
+        check_gpg: false
     image_distribution: rhel-90
     owner: packit-stg
     project: TomasTomecek-aws-cli-1
-    copr_chroot: centos-stream+epel-next-9
+    copr_chroot: centos-stream+epel-next-9-x86_64
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,7 @@ jobs:
     packit_instances: ["stg"]
     targets:
       - centos-stream+epel-next-9
+      - fedora-36-x86_64
   - job: vm_image_build
     trigger: pull_request
     packit_instances: ["stg"]

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,3 +18,20 @@ jobs:
     packit_instances: ["stg"]
     targets:
       - fedora-rawhide
+  - job: vm_image_build
+    trigger: pull_request
+    packit_instances: ["stg"]
+    image_request:
+      architecture: x86_64
+      image_type: aws
+      upload_request:
+        type: aws
+        options:
+          share_with_accounts: ["727920394381"]
+    image_customizations:
+      packages: [awscli]
+    image_distribution: fedora-rawhide
+    owner: packit-stg
+    project: TomasTomecek-aws-cli-1
+    copr_chroot: fedora-rawhide-x86_64
+

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,22 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: awscli.spec
+
+# name in upstream package repository or registry (e.g. in PyPI)
+upstream_package_name: aws-cli
+# downstream (Fedora) RPM package name
+downstream_package_name: awscli
+
+actions:
+  post-upstream-clone:
+  - curl -sLO https://src.fedoraproject.org/rpms/awscli/raw/rawhide/f/awscli.spec
+  - sed -i -e 's/botocore==[0-9.]\+/botocore/' setup.py
+  - sed -i -e 's/botocore==[0-9.]\+/botocore/' setup.cfg
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    packit_instances: ["stg"]
+    targets:
+      - fedora-rawhide

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ universal = 0
 [metadata]
 requires_dist =
         botocore
-        docutils>=0.10,<0.17
+        docutils
         s3transfer
         PyYAML>=3.10,<5.5
         colorama>=0.2.5,<0.4.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ universal = 0
 requires_dist =
         botocore
         docutils>=0.10,<0.17
-        s3transfer>=0.6.0,<0.7.0
+        s3transfer
         PyYAML>=3.10,<5.5
         colorama>=0.2.5,<0.4.5
         rsa>=3.1.2,<4.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 requires_dist =
-        botocore==1.27.69
+        botocore
         docutils>=0.10,<0.17
         s3transfer>=0.6.0,<0.7.0
         PyYAML>=3.10,<5.5

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def find_version(*file_paths):
 
 install_requires = [
     'botocore',
-    'docutils>=0.10,<0.17',
+    'docutils',
     's3transfer',
     'PyYAML>=3.10,<5.5',
     'colorama>=0.2.5,<0.4.5',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def find_version(*file_paths):
 
 
 install_requires = [
-    'botocore==1.27.69',
+    'botocore',
     'docutils>=0.10,<0.17',
     's3transfer>=0.6.0,<0.7.0',
     'PyYAML>=3.10,<5.5',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ def find_version(*file_paths):
 install_requires = [
     'botocore',
     'docutils>=0.10,<0.17',
-    's3transfer>=0.6.0,<0.7.0',
+    's3transfer',
     'PyYAML>=3.10,<5.5',
     'colorama>=0.2.5,<0.4.5',
     'rsa>=3.1.2,<4.8',


### PR DESCRIPTION
Onboarding aws-cli to use [Packit](https://github.com/packit/packit). This enables getting RPM builds and test runs on pull requests, branch pushes and releases.

There is a further proof of concept set up here to create AWS images off pull requests. Contributors then can spin AWS instances, ssh in and play with their change in a live environment.